### PR TITLE
Use Grams

### DIFF
--- a/prodigyplus/core_optimiser.py
+++ b/prodigyplus/core_optimiser.py
@@ -18,6 +18,7 @@ class CoreOptimiser(torch.optim.Optimizer):
                  use_stableadamw=True,
                  use_muon_pp=False,
                  use_cautious=False,
+                 use_grams=False,
                  use_adopt=False,
                  stochastic_rounding=True):
 
@@ -58,6 +59,7 @@ class CoreOptimiser(torch.optim.Optimizer):
                         use_stableadamw=use_stableadamw,
                         use_muon_pp=use_muon_pp,
                         use_cautious=use_cautious,
+                        use_grams=use_grams,
                         use_adopt=use_adopt,
                         stochastic_rounding=stochastic_rounding)
 

--- a/prodigyplus/prodigy_plus_schedulefree.py
+++ b/prodigyplus/prodigy_plus_schedulefree.py
@@ -105,6 +105,12 @@ class ProdigyPlusScheduleFree(CoreOptimiser):
             access to a first moment, so this deviates from the paper (we apply the mask directly to the update).
             May have a limited effect.
             (default: False)
+        use_grams (boolean):
+            Experimental. Perform "grams" updates, as proposed in https://arxiv.org/abs/2412.17107. Modifies 
+            the update using sign operations that align with the current gradient. Note that we do not have
+            access to a first moment, so this deviates from the paper (we apply the sign directly to the update).
+            May have a limited effect.
+            (default: False)            
         use_adopt (boolean):
             Experimental. Performs a modified step where the second moment is updated after the parameter update,
             so as not to include the current gradient in the denominator. This is a partial implementation of ADOPT 
@@ -130,6 +136,7 @@ class ProdigyPlusScheduleFree(CoreOptimiser):
                  use_stableadamw=True,
                  use_muon_pp=False,
                  use_cautious=False,
+                 use_grams=False,
                  use_adopt=False,
                  stochastic_rounding=True):
         
@@ -140,8 +147,8 @@ class ProdigyPlusScheduleFree(CoreOptimiser):
                          eps=eps, split_groups=split_groups,
                          split_groups_mean=split_groups_mean, factored=factored,
                          fused_back_pass=fused_back_pass, use_stableadamw=use_stableadamw,
-                         use_muon_pp=use_muon_pp, use_cautious=use_cautious, use_adopt=use_adopt,
-                         stochastic_rounding=stochastic_rounding)
+                         use_muon_pp=use_muon_pp, use_cautious=use_cautious, use_grams=use_grams, 
+                         use_adopt=use_adopt, stochastic_rounding=stochastic_rounding)
 
     @torch.no_grad()
     def eval(self):
@@ -211,6 +218,14 @@ class ProdigyPlusScheduleFree(CoreOptimiser):
             u.mul_(mask)
             y.sub_(u)
             del mask, u
+
+        if group['use_grams']:
+            # "Grams: Gradient Descent with Adaptive Momentum Scaling": https://arxiv.org/abs/2412.17107
+            u = (y - z).mul_(ckp1).add_(update, alpha=dlr * xy_step)
+            u.copy_(torch.sign(update) * u.abs())
+            y.sub_(u)
+            del u
+
         else:
             y.lerp_(end=z, weight=ckp1)
             y.sub_(update, alpha=dlr * xy_step)


### PR DESCRIPTION
A small and simple update adds the Grams method from:
Grams: Gradient Descent with Adaptive Momentum Scaling
https://arxiv.org/abs/2412.17107
![image](https://github.com/user-attachments/assets/fbbcf47d-907f-451c-b295-70cc326fcb71)
![image](https://github.com/user-attachments/assets/f5e340f8-e73b-4146-ba3c-6a58ecdbdd28)

It seems to converge faster than the cautious method, but its effectiveness on larger-scale training remains uncertain.
Limited testing on my fork shows promising results.